### PR TITLE
Security fixes - WIP

### DIFF
--- a/OctoBTT.sudoers.d
+++ b/OctoBTT.sudoers.d
@@ -1,0 +1,1 @@
+pi ALL=(ALL) NOPASSWD: /sbin/iwlist, /sbin/wpa_cli, /sbin/iwconfig /sbins/ifconfig

--- a/OctoBTT.sudoers.d
+++ b/OctoBTT.sudoers.d
@@ -1,1 +1,1 @@
-pi ALL=(ALL) NOPASSWD: /sbin/iwlist, /sbin/wpa_cli, /sbin/iwconfig /sbins/ifconfig
+pi ALL=(ALL) NOPASSWD: /sbin/iwlist, /sbin/wpa_cli, /sbin/iwconfig, /sbins/ifconfig

--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,13 @@ su -l pi << EOF
 sudo sed -i 's/allowed_users[ ]*=[ ]*console/allowed_users=anybody/g' /etc/X11/Xwrapper.config
 echo "Done."
 
+#Add sudo access for wireless configurations
+echo "Setting up Sudo ..."
+#sudo touch /etc/sudoders.d/OctoBTT
+#sudo echo "pi ALL=(ALL) NOPASSWD: /sbin/iwlist, /sbin/wpa_cli, /sbin/iwconfig, /sbins/ifconfig" > /etc/sudoders.d/OctoBTT
+sudo cp OctoBTT/OctoBTT.sudoers.d /etc/sudoders.d/OctoBTT
+echo "Done."
+
 #Add startup item
 #array=$(sed -n '/^su -l pi -c "startx -- -nocursor"/=' /etc/rc.local)
 #num=${#array}

--- a/install.sh
+++ b/install.sh
@@ -27,9 +27,9 @@ sudo sed -i 's/allowed_users[ ]*=[ ]*console/allowed_users=anybody/g' /etc/X11/X
 echo "Done."
 
 #Add sudo access for wireless configurations
-echo "Setting up Sudo ..."
-#sudo touch /etc/sudoders.d/OctoBTT
-#sudo echo "pi ALL=(ALL) NOPASSWD: /sbin/iwlist, /sbin/wpa_cli, /sbin/iwconfig, /sbins/ifconfig" > /etc/sudoders.d/OctoBTT
+echo "Setting up Sudo for wifi configuration..."
+#sudo touch /etc/sudoers.d/OctoBTT
+#sudo echo "pi ALL=(ALL) NOPASSWD: /sbin/iwlist, /sbin/wpa_cli, /sbin/iwconfig, /sbins/ifconfig" > /etc/sudoers.d/OctoBTT
 sudo cp OctoBTT/OctoBTT.sudoers.d /etc/sudoders.d/OctoBTT
 echo "Done."
 

--- a/terminaldialog.ui
+++ b/terminaldialog.ui
@@ -256,7 +256,7 @@ color: rgb(255, 255, 10);</string>
 color: rgb(0, 255, 0);</string>
      </property>
      <property name="text">
-      <string>sudo iwlist wlan0 scan | grep -E &quot;ESSID|Quality&quot;</string>
+      <string>iwlist wlan0 scan | grep -E &quot;ESSID|Quality&quot;</string>
      </property>
     </widget>
    </item>

--- a/terminaldialog.ui
+++ b/terminaldialog.ui
@@ -256,7 +256,7 @@ color: rgb(255, 255, 10);</string>
 color: rgb(0, 255, 0);</string>
      </property>
      <property name="text">
-      <string>iwlist wlan0 scan | grep -E &quot;ESSID|Quality&quot;</string>
+      <string>sudo iwlist wlan0 scan | grep -E &quot;ESSID|Quality&quot;</string>
      </property>
     </widget>
    </item>

--- a/wlanconfig.cpp
+++ b/wlanconfig.cpp
@@ -1,4 +1,4 @@
-#include "wlanconfig.h"
+include "wlanconfig.h"
 #include "ui_wlanconfig.h"
 #include <mainwindow.h>
 //#include <QSizeF>
@@ -199,7 +199,7 @@ void Wlanconfig::on_Btn_Help_clicked()
 
 void Wlanconfig::GetNetworkInfo()
 {
-    QString cmd = "sudo ifconfig | grep -E \"flags|inet|ether\"";
+    QString cmd = "ifconfig | grep -E \"flags|inet|ether\"";
     disconnect(((MainWindow*)FUI)->terminaldialog,&TerminalDialog::CMD_Reply,0,0);
     QObject::connect(((MainWindow*)FUI)->terminaldialog,&TerminalDialog::CMD_Reply,this,[=](QStringList CommandLine)
                      {

--- a/wlanconfig.cpp
+++ b/wlanconfig.cpp
@@ -1,4 +1,4 @@
-include "wlanconfig.h"
+#include "wlanconfig.h"
 #include "ui_wlanconfig.h"
 #include <mainwindow.h>
 //#include <QSizeF>


### PR DESCRIPTION
Making the software more secure, by removing unneeded sudo commands, and no longer needing the console password. Setting OctoBTT up just like OctoPrint does for it's sudo access.